### PR TITLE
Fix incorrect feature flag on latest nightly.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -18,7 +18,7 @@
 #![feature(conservative_impl_trait)]
 #![feature(specialization)]
 #![feature(unicode)]
-#![feature(print)]
+#![feature(print_internals)]
 #![feature(try_from)]
 
 #[doc(hidden)]


### PR DESCRIPTION
Nightly builds after https://github.com/rust-lang/rust/commit/4ab3bcb9ca137ad6e6ee4ae4a70a234d92b6d4ab replaced #![feature(print)] with #![feature(print_internals)] causing the library to fail to build with the latest nightlies.