### PR TITLE
Add field attributes (aliases, ignore, rename) for derive FormatArgs

### DIFF
--- a/examples/codegen.rs
+++ b/examples/codegen.rs
@@ -24,6 +24,20 @@ struct Alignable {
 #[derive(FormatArgs)]
 struct WithBounds<'a, T: std::fmt::Display + 'a>(&'a T);
 
+#[allow(dead_code)]
+#[derive(FormatArgs)]
+struct WithAttributes {
+    #[format_args(rename = "renamed_field")]
+    field1: &'static str,
+    #[format_args(aliases = "alias")]
+    field2: &'static str,
+    #[format_args(ignore)]
+    ignored: &'static str
+}
+
+#[derive(FormatArgs)]
+struct TupleWithAttributes(#[format_args(rename = "field1")] i32);
+
 fn main() {
     let mut prepared = PreparedFormat::prepare("{left}: {right}").unwrap();
     prepared.newln();
@@ -49,4 +63,24 @@ fn main() {
     });
 
     PreparedFormat::prepare("{}").unwrap().newln().print(&WithBounds(&256));
+
+    let mut prepared = PreparedFormat::prepare(
+r#"WithAttributes {{
+    renamed_field: {renamed_field}
+    field2: {field2}
+    alias: {alias}
+}}"#).unwrap();
+    prepared.newln();
+    prepared.print(&WithAttributes {
+        field1: "field1",
+        field2: "field2",
+        ignored: "ignored"
+    });
+
+    match PreparedFormat::<WithAttributes>::prepare("{ignored}") {
+        Ok(_) => panic!("Field 'ignored' is not ignored"),
+        _ => { }
+    }
+
+    PreparedFormat::prepare("TupleWithAttributes({field1})").unwrap().newln().print(&TupleWithAttributes(256));
 }

--- a/runtime-fmt-derive/src/ast.rs
+++ b/runtime-fmt-derive/src/ast.rs
@@ -1,0 +1,202 @@
+
+use std::borrow::{Borrow, Cow};
+use std::collections::HashSet;
+use syn;
+use syn::Lit::Str;
+use syn::MetaItem::{List, NameValue, Word};
+use syn::NestedMetaItem::MetaItem;
+use ::context::Context;
+
+struct Attribute<'a, T> {
+    context: &'a Context,
+    name: &'static str,
+    value: Option<T>
+}
+
+impl<'a, T> Attribute<'a, T> {
+
+    fn new(context: &'a Context, name: &'static str) -> Self {
+        Attribute {
+            context: context,
+            name: name,
+            value: None
+        }
+    }
+
+    fn set(&mut self, value: T) {
+        if self.value.is_some() {
+            self.context.error(&format!("Duplicate attribute provided: {}", self.name));
+        }
+        else {
+            self.value = Some(value);
+        }
+    }
+
+    fn into(mut self) -> Option<T> {
+        self.value.take()
+    }
+
+}
+
+struct BoolAttribute<'a> {
+    inner: Attribute<'a, ()>
+}
+
+impl<'a> BoolAttribute<'a> {
+
+    fn new(context: &'a Context, name: &'static str) -> Self {
+        BoolAttribute {
+            inner: Attribute::new(context, name)
+        }
+    }
+
+    fn set(&mut self) {
+        self.inner.set(());
+    }
+
+    fn into(self) -> bool {
+        self.inner.into().is_some()
+    }
+
+}
+
+pub struct Container<'a> {
+    ast: &'a syn::DeriveInput,
+
+    fields: Vec<Field<'a>>
+}
+
+impl<'a> Container<'a> {
+
+    pub fn from_ast(ast: &'a syn::DeriveInput) -> Result<Self, String> {
+        let ctx = Context::new();
+
+        let variant = match ast.body {
+            syn::Body::Struct(ref variant) => variant,
+            _ => return Err("#[derive(FormatArgs)] is not implemented for enums".to_string())
+        };
+
+        let fields = {
+            let mut fields = Vec::new();
+            let mut field_names = HashSet::new();
+            for (tuple_index, field) in variant.fields().iter().enumerate() {
+                if let Some(field) = Field::from_ast(&ctx, field, fields.len(), tuple_index) {
+                    for alias in field.aliases() {
+                        if !field_names.insert(*alias) {
+                            ctx.error(&format!("Duplicate field alias: {}", alias));
+                        }
+                    }
+                    fields.push(field);
+                }
+            }
+
+            fields
+        };
+
+        ctx.check().map(|_| {
+            Container {
+                ast: ast,
+
+                fields: fields
+            }
+        })
+    }
+
+    pub fn ident(&self) -> &'a syn::Ident {
+        &self.ast.ident
+    }
+
+    pub fn generics(&self) -> &'a syn::Generics {
+        &self.ast.generics
+    }
+
+    pub fn fields(&self) -> &[Field<'a>] {
+        &self.fields
+    }
+
+}
+
+pub struct Field<'a> {
+    field_index: usize,
+
+    ident: Cow<'a, syn::Ident>,
+    aliases: Vec<&'a str>,
+
+    ty: &'a syn::Ty
+}
+
+impl<'a> Field<'a> {
+
+    pub fn from_ast(ctx: &Context, ast: &'a syn::Field, field_index: usize, tuple_index: usize) -> Option<Self> {
+        let ident = match ast.ident {
+            Some(ref ident) => Cow::Borrowed(ident),
+            None => Cow::Owned(syn::Ident::from(tuple_index))
+        };
+
+        let mut aliases = Attribute::new(ctx, "aliases");
+        let mut ignored = BoolAttribute::new(ctx, "ignore");
+        let mut name = Attribute::new(ctx, "rename");
+
+        for attributes in ast.attrs.iter().filter_map(filter_format_attributes) {
+            for attribute in attributes {
+                match *attribute {
+                    MetaItem(NameValue(ref ident, Str(ref value, _))) if ident == "aliases" => {
+                        aliases.set(value.split(",").collect());
+                    }
+                    MetaItem(NameValue(ref ident, Str(ref value, _))) if ident == "rename" => {
+                        name.set(value.as_ref());
+                    }
+                    MetaItem(Word(ref ident)) if ident == "ignore" => {
+                        ignored.set();
+                    }
+                    _ => ctx.error(&format!("Unrecognized attribute: {:?}", attribute))
+                }
+            }
+        }
+
+        let mut aliases = aliases.into().unwrap_or_else(Vec::new);
+        if let Some(name) = name.into().or(ast.ident.as_ref().map(|ident| ident.as_ref())) {
+            aliases.push(name);
+        }
+
+        if !ignored.into() {
+            Some(Field {
+                field_index: field_index,
+
+                ident: ident,
+                aliases: aliases,
+
+                ty: &ast.ty
+            })
+        }
+        else {
+            None
+        }
+    }
+
+    pub fn index(&self) -> usize {
+        self.field_index
+    }
+
+    pub fn ident(&self) -> &syn::Ident {
+        self.ident.borrow()
+    }
+
+    pub fn aliases(&self) -> &[&'a str] {
+        &self.aliases
+    }
+
+    pub fn ty(&self) -> &'a syn::Ty {
+        self.ty
+    }
+
+}
+
+fn filter_format_attributes(attr: &syn::Attribute) -> Option<&Vec<syn::NestedMetaItem>> {
+    match attr.value {
+        List(ref name, ref items) if name == "format_args" => {
+            Some(items)
+        }
+        _ => None
+    }
+}

--- a/runtime-fmt-derive/src/context.rs
+++ b/runtime-fmt-derive/src/context.rs
@@ -1,0 +1,44 @@
+
+use std::cell::RefCell;
+
+pub struct Context {
+    error: RefCell<Option<String>>
+}
+
+impl Context {
+
+    pub fn new() -> Self {
+        Context {
+            error: RefCell::new(Some(String::new()))
+        }
+    }
+
+    pub fn error(&self, error: &str) {
+        let mut cur_error = self.error.borrow_mut();
+        let mut cur_error = cur_error.get_or_insert_with(String::new);
+
+        if !cur_error.is_empty() {
+            cur_error.push('\n');
+        }
+        *cur_error += &error;
+    }
+
+    pub fn check(&self) -> Result<(), String> {
+        self.error.borrow_mut()
+            .take().into_iter()
+            .filter(|s| !s.is_empty())
+            .next()
+            .map_or(Ok(()), Err)
+    }
+
+}
+
+impl Drop for Context {
+
+    fn drop(&mut self) {
+        if self.error.borrow().is_some() {
+            panic!("Failed to check for errors in context");
+        }
+    }
+
+}

--- a/tests/codegen.rs
+++ b/tests/codegen.rs
@@ -1,0 +1,106 @@
+#[macro_use] extern crate runtime_fmt_derive;
+extern crate runtime_fmt;
+
+use runtime_fmt::{FormatArgs, PreparedFormat};
+
+#[test]
+#[allow(dead_code)]
+fn test_struct() {
+    #[derive(FormatArgs)]
+    struct Struct {
+        #[format_args(aliases = "alias1,alias2")]
+        field1: &'static str,
+        field2: &'static str,
+        field3: usize,
+        #[format_args(rename = "renamed")]
+        field4: &'static str,
+        #[format_args(ignore)]
+        ignored: &'static str
+    }
+
+    assert_eq!(Struct::validate_name("field1").is_some(), true);
+    assert_eq!(Struct::validate_name("field1"), Struct::validate_name("alias1"));
+    assert_eq!(Struct::validate_name("field1"), Struct::validate_name("alias2"));
+
+    assert_eq!(Struct::validate_name("field2").is_some(), true);
+    assert_eq!(Struct::validate_name("field3").is_some(), true);
+
+    assert_eq!(Struct::validate_name("field4").is_some(), false);
+    assert_eq!(Struct::validate_name("renamed").is_some(), true);
+
+    assert_eq!(Struct::validate_name("ignored").is_some(), false);
+
+    assert_eq!(Struct::validate_index(0), true);
+    assert_eq!(Struct::validate_index(1), true);
+    assert_eq!(Struct::validate_index(2), true);
+    assert_eq!(Struct::validate_index(3), true);
+    assert_eq!(Struct::validate_index(4), false);
+
+    assert_eq!(Struct::as_usize(0).is_some(), false);
+    assert_eq!(Struct::as_usize(1).is_some(), false);
+    assert_eq!(Struct::as_usize(2).is_some(), true);
+    assert_eq!(Struct::as_usize(3).is_some(), false);
+
+    let value = Struct {
+        field1: "value1",
+        field2: "value2",
+        field3: 123456,
+        field4: "value4",
+        ignored: "ignored"
+    };
+
+    let fmt = PreparedFormat::prepare("{field1} {alias1} {alias2} {field2} {field3} {renamed}").unwrap().format(&value);
+    assert_eq!(fmt, "value1 value1 value1 value2 123456 value4");
+
+    let fmt = PreparedFormat::prepare("{0} {1} {2} {3}").unwrap().format(&value);
+    assert_eq!(fmt, "value1 value2 123456 value4");
+}
+
+#[test]
+fn test_tuple() {
+    #[derive(FormatArgs)]
+    struct Tuple(
+        #[format_args(aliases = "alias1,alias2")]
+        &'static str,
+        &'static str,
+        usize,
+        #[format_args(rename = "renamed")]
+        &'static str,
+        #[format_args(ignore)]
+        &'static str
+    );
+
+    assert_eq!(Tuple::validate_name("alias1").is_some(), true);
+    assert_eq!(Tuple::validate_name("alias1"), Tuple::validate_name("alias2"));
+    assert_eq!(Tuple::validate_name("renamed").is_some(), true);
+
+    assert_eq!(Tuple::validate_index(0), true);
+    assert_eq!(Tuple::validate_index(1), true);
+    assert_eq!(Tuple::validate_index(2), true);
+    assert_eq!(Tuple::validate_index(3), true);
+    assert_eq!(Tuple::validate_index(4), false);
+
+    assert_eq!(Tuple::as_usize(0).is_some(), false);
+    assert_eq!(Tuple::as_usize(1).is_some(), false);
+    assert_eq!(Tuple::as_usize(2).is_some(), true);
+    assert_eq!(Tuple::as_usize(3).is_some(), false);
+
+    let value = Tuple("value1", "value2", 123456, "value3", "ignored");
+
+    let fmt = PreparedFormat::prepare("{alias1} {alias2} {renamed}").unwrap().format(&value);
+    assert_eq!(fmt, "value1 value1 value3");
+
+    let fmt = PreparedFormat::prepare("{0} {1} {2} {3}").unwrap().format(&value);
+    assert_eq!(fmt, "value1 value2 123456 value3");
+}
+
+#[test]
+fn test_unit() {
+    #[derive(FormatArgs)]
+    struct Unit;
+
+    assert_eq!(Unit::validate_index(0), false);
+
+    let fmt = PreparedFormat::prepare("").unwrap().format(&Unit);
+    assert_eq!(fmt, "");
+}


### PR DESCRIPTION
Implements support for field attributes when using `#derive(FormatArgs)` on a struct. Adding these attributes allows for hiding of internal fields, or providing backwards compatible names for given fields. 

`aliases` - Comma separated list of alternative names for the provided field.
`ignore` - If set, field is hidden from format strings.
`rename` - Overrides the default name for a given field.

This pull request also refactored most of the generation code. While the generated code mostly matches, regular structs now also support indices similar to tuple structs and tuple structs can have named fields using the added attributes. This was done to unify the code and make it agnostic of struct type.