### PR TITLE
Change unicode to rustc_private feature.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,8 +17,8 @@
 #![feature(fmt_internals)]
 #![feature(conservative_impl_trait)]
 #![feature(specialization)]
-#![feature(unicode)]
 #![feature(print_internals)]
+#![feature(rustc_private)]
 #![feature(try_from)]
 
 #[doc(hidden)]


### PR DESCRIPTION
Nightly builds after https://github.com/rust-lang/rust/commit/c6afde6c46d167c9c75389b887f1d2498aeef3e4 replaced the unicode feature gate with rustc_private.