### PR TITLE
Fixes compile error in Rust 1.38

### DIFF
--- a/src/codegen.rs
+++ b/src/codegen.rs
@@ -27,7 +27,7 @@ trait Specialized<T> {
 macro_rules! impl_format_trait {
     ($($name:ident,)*) => {
         $(
-            impl<T> Specialized<T> for $name {
+            impl<T> Specialized<T> for dyn $name {
                 #[inline]
                 default fn allowed() -> bool { false }
                 #[inline]
@@ -36,7 +36,7 @@ macro_rules! impl_format_trait {
                 }
             }
 
-            impl<T: $name> Specialized<T> for $name {
+            impl<T: $name> Specialized<T> for dyn $name {
                 #[inline]
                 fn allowed() -> bool { true }
                 #[inline]
@@ -45,7 +45,7 @@ macro_rules! impl_format_trait {
                 }
             }
 
-            impl FormatTrait for $name {
+            impl FormatTrait for dyn $name {
                 #[inline]
                 fn allowed<T>() -> bool { <Self as Specialized<T>>::allowed() }
                 #[inline]

--- a/src/erase.rs
+++ b/src/erase.rs
@@ -68,7 +68,7 @@ macro_rules! traits {
         {
             match name {
                 $(
-                    $string => match T::get_child::<fmt::$upper>(idx) {
+                    $string => match T::get_child::<dyn fmt::$upper>(idx) {
                         Some(f) => Ok(f),
                         None => Err(Error::UnsatisfiedFormat {
                             idx: idx,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,11 +15,10 @@
 //! arguments. This crate shells out to the standard library implementations
 //! for as much as possible to ensure feature parity.
 #![feature(fmt_internals)]
-#![feature(conservative_impl_trait)]
+#![feature(unicode_internals)]
 #![feature(specialization)]
 #![feature(print_internals)]
 #![feature(rustc_private)]
-#![feature(try_from)]
 
 #[doc(hidden)]
 #[inline]
@@ -92,7 +91,7 @@ impl<'a> std::error::Error for Error<'a> {
             Error::Fmt(ref f) => f.description(),
         }
     }
-    fn cause(&self) -> Option<&std::error::Error> {
+    fn cause(&self) -> Option<&dyn std::error::Error> {
         match *self {
             Error::Io(ref e) => Some(e),
             Error::Fmt(ref e) => Some(e),
@@ -131,7 +130,7 @@ impl<'a> fmt::Display for Error<'a> {
 /// A type-erased parameter, with an optional name.
 pub struct Param<'a> {
     name: Option<&'static str>,
-    value: &'a erase::Format,
+    value: &'a dyn erase::Format,
     as_usize: Option<usize>,
 }
 

--- a/tests/ifmt.rs
+++ b/tests/ifmt.rs
@@ -124,7 +124,7 @@ pub fn main() {
     t!(format!("{:#4}", C), "☃123");
     t!(format!("{:b}", D), "aa☃bb");
 
-    let a: &fmt::Debug = &1;
+    let a: &dyn fmt::Debug = &1;
     t!(format!("{:?}", a), "1");
 
 


### PR DESCRIPTION
Added `feature(unicode_internals)`.
Removed old features.
Added `dyn` keyword where needed.

@SpaceManiac This crate fails to compile with 1.38. It is used on the https://riker.rs framework - can you review this PR and publish an update so that we can also compile.

Thank you.

---

ed. Fixes #7